### PR TITLE
P3P header value is now optionally defineable in the service arguments.

### DIFF
--- a/EventListener/ResponseListener.php
+++ b/EventListener/ResponseListener.php
@@ -6,6 +6,13 @@ use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
  
 class ResponseListener
 {
+    /* @var string */
+    private $headerValue;
+
+    public function __construct($headerValue = null) {
+        $this->headerValue = !is_null($headerValue) ? $headerValue :
+                'CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"';
+    }
     public function onKernelResponse(FilterResponseEvent $event)
     {
         $request = $event->getRequest();
@@ -16,6 +23,6 @@ class ResponseListener
         }
          
         // set the "P3P" header of the response
-        $event->getResponse()->headers->set('P3P', 'CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"');
+        $event->getResponse()->headers->set('P3P', $this->headerValue);
     }
 }


### PR DESCRIPTION
Small change to allow defining the content of the P3P header.
